### PR TITLE
fix: allow angular 8 peer dependency

### DIFF
--- a/src/lib/picker/package.json
+++ b/src/lib/picker/package.json
@@ -7,8 +7,8 @@
   },
   "description": "Customizable Slack-like emoji picker for Angular",
   "peerDependencies": {
-    "@angular/core": "^6.0.0 || ^7.0.0",
-    "@angular/common": "^6.0.0 || ^7.0.0"
+    "@angular/core": ">=6.0.0 <9.0.0",
+    "@angular/common": ">=6.0.0 <9.0.0"
   },
   "bugs": "https://github.com/TypeCtrl/ngx-emoji-mart/issues",
   "homepage": "https://github.com/TypeCtrl/ngx-emoji-mart",


### PR DESCRIPTION
Angular 8 is coming, so this patch allows the angular 8 peer dependency

Thanks for your work on this library! 😄