### PR TITLE
fix: Enable to search "+1" for "thumbsup"

### DIFF
--- a/src/lib/picker/emoji-search.service.ts
+++ b/src/lib/picker/emoji-search.service.ts
@@ -65,6 +65,9 @@ export class EmojiSearch {
       if (value === '-' || value === '-1') {
         return [this.emojisList['-1']];
       }
+      if (value === '+' || value === '+1') {
+        return [this.emojisList['+1']];
+      }
 
       let values = value.toLowerCase().split(/[\s|,|\-|_]+/);
       let allResults = [];


### PR DESCRIPTION
It is a nitpick. If "-1" is searchable, why not for "+1"?