### PR TITLE
feat: Picker show up faster

### DIFF
--- a/src/lib/picker/picker.component.ts
+++ b/src/lib/picker/picker.component.ts
@@ -238,9 +238,17 @@ export class PickerComponent implements OnInit {
     this.categories.unshift(this.SEARCH_CATEGORY);
     this.selected = this.categories.filter(category => category.first)[0].name;
 
-    this.setActiveCategories(this.activeCategories = this.categories.slice(0, 3));
+    const categoriesToLoadFirst = 3;
+    this.setActiveCategories(this.activeCategories = this.categories.slice(0, categoriesToLoadFirst));
+    // Trim last active category
+    const lastActiveCategoryEmojis = this.categories[categoriesToLoadFirst - 1].emojis.slice();
+    this.categories[categoriesToLoadFirst - 1].emojis = lastActiveCategoryEmojis.slice(0, 60);
+
+    this.ref.markForCheck();
 
     setTimeout(() => {
+      // Restore last category
+      this.categories[categoriesToLoadFirst - 1].emojis = lastActiveCategoryEmojis;
       this.setActiveCategories(this.categories);
       this.ref.markForCheck();
       setTimeout(() => this.updateCategoriesSize());


### PR DESCRIPTION
There was already something for the picker to load initially 3 categories, but the third category (faces by default) has around 400 emojis and take a long time to render. I shortened the last category to 60 emojis in the initial load and load the rest after that.