### PR TITLE
Change picker search box-sizing.

### DIFF
--- a/src/lib/picker/picker.css
+++ b/src/lib/picker/picker.css
@@ -94,6 +94,7 @@
   display: block;
   width: 100%;
   padding: 5px 25px 6px 10px;
+  box-sizing:border-box;
   border-radius: 5px;
   border: 1px solid #d9d9d9;
   outline: 0;


### PR DESCRIPTION
Reason : Width 100% + padding : Picker will overflow unless we change box-sizing.