### PR TITLE
fix: limit search when using showSingleCategory #212

### DIFF
--- a/src/lib/picker/picker.component.ts
+++ b/src/lib/picker/picker.component.ts
@@ -256,7 +256,9 @@ export class PickerComponent implements OnInit {
   }
   setActiveCategories(categoriesToMakeActive: Array<EmojiCategory>) {
     if (this.showSingleCategory) {
-      this.activeCategories = categoriesToMakeActive.filter(x => x.name === this.selected);
+      this.activeCategories = categoriesToMakeActive.filter(
+        x => (x.name === this.selected || x === this.SEARCH_CATEGORY)
+      );
     } else {
       this.activeCategories = categoriesToMakeActive;
     }


### PR DESCRIPTION
This is a straight forward fix for broken search when [showSingleCategory]="true". We simply need to make sure that the "Search" category is contained in activeCategories.

There are still other issues with search, e.g., #172, but we can get this one out of the way for the time being.

closes #212 