### PR TITLE
fix: patch for include and exclude parameters #172

### DIFF
--- a/src/lib/picker/emoji-search.service.ts
+++ b/src/lib/picker/emoji-search.service.ts
@@ -93,7 +93,12 @@ export class EmojiSearch {
           }
 
           category.emojis.forEach(
-            emojiId => (pool[emojiId] = this.emojiService.names[emojiId]),
+            emojiId => {
+              // Need to make sure that pool gets keyed
+              // with the correct id, which is why we call emojiService.getData below
+              let emoji = this.emojiService.getData(emojiId);
+              pool[emoji.id] = emoji;
+            }
           );
         });
 

--- a/src/lib/picker/picker.component.ts
+++ b/src/lib/picker/picker.component.ts
@@ -238,8 +238,10 @@ export class PickerComponent implements OnInit {
     this.categories.unshift(this.SEARCH_CATEGORY);
     this.selected = this.categories.filter(category => category.first)[0].name;
 
-    const categoriesToLoadFirst = 3;
+    // Need to be careful if small number of categories
+    let categoriesToLoadFirst = Math.min(this.categories.length, 3);
     this.setActiveCategories(this.activeCategories = this.categories.slice(0, categoriesToLoadFirst));
+
     // Trim last active category
     const lastActiveCategoryEmojis = this.categories[categoriesToLoadFirst - 1].emojis.slice();
     this.categories[categoriesToLoadFirst - 1].emojis = lastActiveCategoryEmojis.slice(0, 60);


### PR DESCRIPTION
emoji-search.service.ts: Pool variable was getting set with incorrect id (emojiId) ... needed to grab emoji object first to obtain the correct id, and then set the correct key (emoji.id) on pool object.

picker.component.ts: Was getting console error (undefined object) with small number of categories. This fixes it. 

Closes #172 