### PR TITLE
fix: broken search when using [emojisToShowFilter] #182

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -60,4 +60,11 @@ export class AppComponent {
   handleClick($event: EmojiEvent) {
     console.log($event.emoji);
   }
+  emojiFilter(e: string): boolean {
+    // Can use this to test [emojisToShowFilter]
+    if (e && e.indexOf && e.indexOf('1F4') >= 0) {
+      return true;
+    }
+    return false;
+  }
 }

--- a/src/lib/picker/emoji-search.service.ts
+++ b/src/lib/picker/emoji-search.service.ts
@@ -187,9 +187,12 @@ export class EmojiSearch {
 
     if (results) {
       if (emojisToShowFilter) {
-        results = results.filter((result: EmojiData) =>
-          emojisToShowFilter(this.emojiService.names[result.id]),
-        );
+        results = results.filter((result: EmojiData) => {
+          if (result && result.id) {
+            return emojisToShowFilter(this.emojiService.names[result.id].unified);
+          }
+          return false;
+        });
       }
 
       if (results && results.length > maxResults) {


### PR DESCRIPTION
**app.component.ts**: Added filter function to easily test [emojisToShowFilter].

**emoji-search.service.ts**: Need to pass "unified" string to the filter function rather than Emoji object. Also added in some guards for undefined result, which was causing issues in some cases. 

closes #182 