### PR TITLE
fix: enable useButton flag for normally rendered emojis

### DIFF
--- a/src/lib/picker/category.component.ts
+++ b/src/lib/picker/category.component.ts
@@ -96,6 +96,7 @@ import { EmojiFrequentlyService } from './emoji-frequently.service';
           [backgroundImageFn]="emojiBackgroundImageFn"
           [imageUrlFn]="emojiImageUrlFn"
           [hideObsolete]="hideObsolete"
+          [useButton]="emojiUseButton"
           (emojiOver)="emojiOver.emit($event)"
           (emojiLeave)="emojiLeave.emit($event)"
           (emojiClick)="emojiClick.emit($event)"


### PR DESCRIPTION
I noticed the useButton input wasn't being set for ngx-emoji in normalRenderTemplate. Would be great if it could be fixed, unless that's intended.