### PR TITLE
Fix blank category area for enabled virtualization

### DIFF
--- a/src/lib/picker/picker.component.ts
+++ b/src/lib/picker/picker.component.ts
@@ -378,9 +378,11 @@ export class PickerComponent implements OnInit, OnDestroy {
       if (target.scrollTop === 0) {
         // hit the TOP
         activeCategory = this.categories.find(n => n.first === true);
+        this.categoryRefs.forEach((component) => component.handleScroll(target.scrollTop));
       } else if (target.scrollHeight - target.scrollTop === this.clientHeight) {
         // scrolled to bottom activate last category
         activeCategory = this.categories[this.categories.length - 1];
+        this.categoryRefs.forEach((component) => component.handleScroll(target.scrollTop));
       } else {
         // scrolling
         for (const category of this.categories) {


### PR DESCRIPTION
It fixes the blank category section when the user scrolls up or down directly via the scrollbar.

<img width="992" alt="Screenshot 2024-11-15 at 03 05 23" src="https://github.com/user-attachments/assets/bd039969-3991-45da-ba39-c7f540d8f0d4">
